### PR TITLE
Added support for 301 & 302 response redirection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 pkg
 *.gem
+*.*~
+*~
+*.pyc
+*.swp
+*.swo
+build/
+

--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,10 @@ Connection options:
 
     Nestful.get 'http://example.com' #=> "body"
 
+with redirection
+
+    Nestful.get 'http://apple.com', :allow_redirect => true
+
 ### POST request
 
     Nestful.post 'http://example.com', :format => :form #=> "body"

--- a/lib/nestful/connection.rb
+++ b/lib/nestful/connection.rb
@@ -145,7 +145,7 @@ module Nestful
       def handle_response(response)
         case response.code.to_i
           when 301,302
-            raise(Redirection.new(response))
+            response
           when 200...400
             response
           when 400

--- a/lib/nestful/request.rb
+++ b/lib/nestful/request.rb
@@ -86,7 +86,13 @@ module Nestful
         }
       end
       callback(:after_request, self, result)
-      result
+      response = result.response
+      # If response is a redirect and :allow_redirect is true issue another request
+      if @options.key? :allow_redirect and response.header.key?('Location') and [301, 302].include?(response.code.to_i)
+          Request.new(result.response.header['Location'], options).execute
+      else
+          result
+      end
     end
             
     protected    


### PR DESCRIPTION
https://github.com/maccman/nestful/issues/4

If :allow_redirects is true, response status code is 301 or 302 and it contains Location header, then the exact request is made on header['Location']
