### PR TITLE
Getting rid of deprecated ActiveSupport::SecureRandom.

### DIFF
--- a/lib/nestful/formats/multipart_format.rb
+++ b/lib/nestful/formats/multipart_format.rb
@@ -1,4 +1,4 @@
-require 'active_support/secure_random'
+require 'securerandom'
 
 module Nestful
   module Formats
@@ -9,7 +9,7 @@ module Nestful
       
       def initialize(*args)
         super
-        @boundary = ActiveSupport::SecureRandom.hex(10)
+        @boundary = SecureRandom.hex(10)
         @stream   = Tempfile.new("nf.#{rand(1000)}")
         @stream.binmode
       end


### PR DESCRIPTION
Rails has deprecated SecureRandom from ActiveSupport in 3.1
Rails has removed SecureRandom from ActiveSupport in 3.2
