### PR TITLE
Change multipart handling to check for object#read instead of specific object types

### DIFF
--- a/lib/nestful/formats/multipart_format.rb
+++ b/lib/nestful/formats/multipart_format.rb
@@ -4,9 +4,9 @@ module Nestful
   module Formats
     class MultipartFormat < Format
       EOL = "\r\n"
-      
+
       attr_reader :boundary, :stream
-      
+
       def initialize(*args)
         super
         @boundary = SecureRandom.hex(10)
@@ -29,7 +29,7 @@ module Nestful
       def decode(body)
         body
       end
-  
+
       protected
         def to_multipart(params, namespace = nil)
           params.each do |key, value|
@@ -43,14 +43,14 @@ module Nestful
 
             stream.write("--" + boundary + EOL)
 
-            if value.is_a?(File) || value.is_a?(StringIO) || value.is_a?(Tempfile)
+            if value.respond_to?(:read)
               create_file_field(key, value)
             else
               create_field(key, value)
             end
-          end          
+          end
         end
-      
+
         def create_file_field(key, value)
           stream.write(%Q{Content-Disposition: form-data; name="#{key}"; filename="#{filename(value)}"} + EOL)
           stream.write(%Q{Content-Type: application/octet-stream} + EOL)
@@ -61,14 +61,14 @@ module Nestful
           end
           stream.write(EOL)
         end
-    
+
         def create_field(key, value)
           stream.write(%Q{Content-Disposition: form-data; name="#{key}"} + EOL)
           stream.write(EOL)
           stream.write(value)
           stream.write(EOL)
         end
-  
+
         def filename(body)
           return body.original_filename   if body.respond_to?(:original_filename)
           return File.basename(body.path) if body.respond_to?(:path)


### PR DESCRIPTION
This change allows passing params[:file] in a Rails 3.2 upload directly into Nestful's post function (Rails 3.2 wraps the uploaded file in yet another object type).  Really all we need to know is whether the object responds to read, in other words; does it act like a StringIO object?

The changeset has a bunch of deleted whitespace because SublimeText strips extra whitespace out of blank lines automatically.  

Edit:  I just saw that this pull request has two unnecessary commits (which don't change anything, overall).  Feel free to reject it and make the changes yourself in a cleaner way if you prefer.
