### PR TITLE
When redirecting use the previous scheme to make the request if scheme is missing

### DIFF
--- a/lib/nestful/version.rb
+++ b/lib/nestful/version.rb
@@ -1,3 +1,3 @@
 module Nestful
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'.freeze
 end


### PR DESCRIPTION
If the `Location` header is missing the scheme, we will assume it was meant to be `http`. Should we make it assume to be what the original request was made with?