### PR TITLE
refactor endpoint methods

### DIFF
--- a/lib/nestful/endpoint.rb
+++ b/lib/nestful/endpoint.rb
@@ -20,23 +20,26 @@ module Nestful
     end
 
     def get(params = {}, options = {})
-      request(options.merge(:method => :get, :params => params))
+      request(:get, params, options)
     end
 
     def put(params = {}, options = {})
-      request(options.merge(:method => :put, :params => params))
+      request(:put, params, options)
     end
 
     def post(params = {}, options = {})
-      request(options.merge(:method => :post, :params => params))
+      request(:post, params, options)
     end
 
     def delete(params = {}, options = {})
-      request(options.merge(:method => :delete, :params => params))
+      request(:delete, params, options)
     end
 
-    def request(options = {})
-      Request.new(url, options.merge(@options)).execute
+    private
+
+    def request(method, params, options)
+      options = @options.merge(options.merge(:method => method, :params => params))
+      Request.new(url, options).execute
     end
   end
 end


### PR DESCRIPTION
Refactor how `request` object is created under Nestful::Endpoint. 

Also:
- Hides `request` method under private visibility. 
- Removes default parameter `options = {}` from `request` as it is only called from these class methods and they all have default guards. 