### PR TITLE
Include name of open source license in gem metadata

### DIFF
--- a/nestful.gemspec
+++ b/nestful.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["info@eribium.org"]
   gem.summary       = %q{Simple Ruby HTTP/REST client with a sane API}
   gem.homepage      = "https://github.com/maccman/nestful"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
It's useful to be able to determine the license of a gem dependencies programmatically e.g. for auditing purposes.

This change sets the `license` value in `nestful.gemspec` to `"MIT"` which was inferred from the license file found it the root of the project (see `MIT-LICENSE`).

When this change is incorporated you can then determine the license of the `nestful` gem programmatically e.g.:

```ruby
# before
Gem.loaded_specs['nestful'].licenses
=> []

# after
Gem.loaded_specs['nestful'].licenses
=> ["MIT"]
```